### PR TITLE
[KW-592] feat: 건물 출입 로그 Redis Stream 저장 구현

### DIFF
--- a/src/main/java/com/doubleo/passservice/domain/log/consumer/AreaEnterLogConsumer.java
+++ b/src/main/java/com/doubleo/passservice/domain/log/consumer/AreaEnterLogConsumer.java
@@ -39,7 +39,7 @@ public class AreaEnterLogConsumer {
         }
     }
 
-    @Scheduled(fixedDelay = 10000)
+    @Scheduled(fixedDelay = 300000)
     public void consumeMessages() {
         List<MapRecord<String, Object, Object>> messages =
                 redisTemplate

--- a/src/main/java/com/doubleo/passservice/domain/log/consumer/AreaEnterLogConsumer.java
+++ b/src/main/java/com/doubleo/passservice/domain/log/consumer/AreaEnterLogConsumer.java
@@ -1,0 +1,73 @@
+package com.doubleo.passservice.domain.log.consumer;
+
+import com.doubleo.passservice.domain.log.domain.EnterLog;
+import com.doubleo.passservice.domain.log.repository.EnterLogRepository;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.connection.stream.StreamReadOptions;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AreaEnterLogConsumer {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final EnterLogRepository enterLogRepository;
+
+    private static final String STREAM_KEY = "area:enter:stream";
+    private static final String GROUP = "area:enter:group";
+    private static final String CONSUMER_NAME = "area-enter-consumer-1";
+
+    @PostConstruct
+    public void initGroup() {
+        try {
+            redisTemplate.opsForStream().createGroup(STREAM_KEY, GROUP);
+        } catch (Exception e) {
+            if (!e.getMessage().contains("BUSYGROUP")) {
+                log.warn("Stream group 생성 실패: {}", e.getMessage());
+            }
+        }
+    }
+
+    @Scheduled(fixedDelay = 10000)
+    public void consumeMessages() {
+        List<MapRecord<String, Object, Object>> messages =
+                redisTemplate
+                        .opsForStream()
+                        .read(
+                                Consumer.from(GROUP, CONSUMER_NAME),
+                                StreamReadOptions.empty().count(100),
+                                StreamOffset.create(STREAM_KEY, ReadOffset.lastConsumed()));
+
+        for (MapRecord<String, Object, Object> msg : messages) {
+            Map<Object, Object> data = msg.getValue();
+
+            EnterLog enterLog =
+                    EnterLog.createEnterLog(
+                            (String) data.get("tenantId"),
+                            Long.parseLong((String) data.get("areaId")),
+                            Long.parseLong((String) data.get("memberId")),
+                            (String) data.get("memberName"),
+                            Long.parseLong((String) data.get("passId")));
+
+            enterLogRepository.save(enterLog);
+            redisTemplate.opsForStream().acknowledge(GROUP, msg);
+
+            log.info(
+                    "AreaEnterLog 저장 완료: memberId={}, areaId={}, tenantId={}",
+                    enterLog.getMemberId(),
+                    enterLog.getAreaId(),
+                    enterLog.getTenantId());
+        }
+    }
+}

--- a/src/main/java/com/doubleo/passservice/domain/log/consumer/BuildingEnterLogConsumer.java
+++ b/src/main/java/com/doubleo/passservice/domain/log/consumer/BuildingEnterLogConsumer.java
@@ -1,0 +1,75 @@
+package com.doubleo.passservice.domain.log.consumer;
+
+import com.doubleo.passservice.domain.log.domain.BuildingEnterLog;
+import com.doubleo.passservice.domain.log.domain.Direction;
+import com.doubleo.passservice.domain.log.repository.BuildingEnterLogRepository;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.connection.stream.StreamReadOptions;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BuildingEnterLogConsumer {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final BuildingEnterLogRepository buildingEnterLogRepository;
+
+    private static final String STREAM_KEY = "building:enter:stream";
+    private static final String GROUP = "building:enter:group";
+    private static final String CONSUMER_NAME = "building-enter-consumer-1";
+
+    @PostConstruct
+    public void initGroup() {
+        try {
+            redisTemplate.opsForStream().createGroup(STREAM_KEY, GROUP);
+        } catch (Exception e) {
+            if (!e.getMessage().contains("BUSYGROUP")) {
+                log.warn("Stream group 생성 실패: {}", e.getMessage());
+            }
+        }
+    }
+
+    @Scheduled(fixedDelay = 10000)
+    public void consumeMessages() {
+        List<MapRecord<String, Object, Object>> messages =
+                redisTemplate
+                        .opsForStream()
+                        .read(
+                                Consumer.from(GROUP, CONSUMER_NAME),
+                                StreamReadOptions.empty().count(100),
+                                StreamOffset.create(STREAM_KEY, ReadOffset.lastConsumed()));
+
+        for (MapRecord<String, Object, Object> msg : messages) {
+            Map<Object, Object> data = msg.getValue();
+
+            BuildingEnterLog buildingEnterLog =
+                    BuildingEnterLog.createBuildingEnterLog(
+                            Long.parseLong((String) data.get("buildingId")),
+                            Long.parseLong((String) data.get("memberId")),
+                            (String) data.get("memberName"),
+                            Long.parseLong((String) data.get("passId")),
+                            Direction.valueOf(((String) data.get("direction")).toUpperCase()),
+                            (String) data.get("tenantId"));
+
+            buildingEnterLogRepository.save(buildingEnterLog);
+            redisTemplate.opsForStream().acknowledge(GROUP, msg);
+
+            log.info(
+                    "BuildingEnterLog 저장 완료: memberId={}, buildingId={}, tenantId={}",
+                    buildingEnterLog.getMemberId(),
+                    buildingEnterLog.getBuildingId(),
+                    buildingEnterLog.getTenantId());
+        }
+    }
+}

--- a/src/main/java/com/doubleo/passservice/domain/log/consumer/BuildingEnterLogConsumer.java
+++ b/src/main/java/com/doubleo/passservice/domain/log/consumer/BuildingEnterLogConsumer.java
@@ -55,13 +55,12 @@ public class BuildingEnterLogConsumer {
 
             BuildingEnterLog buildingEnterLog =
                     BuildingEnterLog.createBuildingEnterLog(
+                            (String) data.get("tenantId"),
                             Long.parseLong((String) data.get("buildingId")),
                             Long.parseLong((String) data.get("memberId")),
                             (String) data.get("memberName"),
                             Long.parseLong((String) data.get("passId")),
-                            Direction.valueOf(((String) data.get("direction")).toUpperCase()),
-                            (String) data.get("tenantId"));
-
+                            Direction.valueOf(((String) data.get("direction")).toUpperCase()));
             buildingEnterLogRepository.save(buildingEnterLog);
             redisTemplate.opsForStream().acknowledge(GROUP, msg);
 

--- a/src/main/java/com/doubleo/passservice/domain/log/consumer/BuildingEnterLogConsumer.java
+++ b/src/main/java/com/doubleo/passservice/domain/log/consumer/BuildingEnterLogConsumer.java
@@ -40,7 +40,7 @@ public class BuildingEnterLogConsumer {
         }
     }
 
-    @Scheduled(fixedDelay = 10000)
+    @Scheduled(fixedDelay = 300000)
     public void consumeMessages() {
         List<MapRecord<String, Object, Object>> messages =
                 redisTemplate

--- a/src/main/java/com/doubleo/passservice/domain/log/domain/BuildingEnterLog.java
+++ b/src/main/java/com/doubleo/passservice/domain/log/domain/BuildingEnterLog.java
@@ -8,7 +8,6 @@ import lombok.*;
 @Table(name = "building_enter_log")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class BuildingEnterLog extends BaseEntity {
 
@@ -33,20 +32,36 @@ public class BuildingEnterLog extends BaseEntity {
     @Column(name = "direction", nullable = false, length = 10)
     private Direction direction;
 
-    public static BuildingEnterLog createBuildingEnterLog(
+    @Builder(access = AccessLevel.PRIVATE)
+    private BuildingEnterLog(
+            String tenantId,
             Long buildingId,
             Long memberId,
             String memberName,
             Long passId,
-            Direction direction,
-            String tenantId) {
-        BuildingEnterLog log = new BuildingEnterLog();
-        log.buildingId = buildingId;
-        log.memberId = memberId;
-        log.memberName = memberName;
-        log.passId = passId;
-        log.direction = direction;
-        log.tenantId = tenantId;
-        return log;
+            Direction direction) {
+        this.tenantId = tenantId;
+        this.buildingId = buildingId;
+        this.memberId = memberId;
+        this.memberName = memberName;
+        this.passId = passId;
+        this.direction = direction;
+    }
+
+    public static BuildingEnterLog createBuildingEnterLog(
+            String tenantId,
+            Long buildingId,
+            Long memberId,
+            String memberName,
+            Long passId,
+            Direction direction) {
+        return BuildingEnterLog.builder()
+                .tenantId(tenantId)
+                .buildingId(buildingId)
+                .memberId(memberId)
+                .memberName(memberName)
+                .passId(passId)
+                .direction(direction)
+                .build();
     }
 }

--- a/src/main/java/com/doubleo/passservice/domain/log/domain/BuildingEnterLog.java
+++ b/src/main/java/com/doubleo/passservice/domain/log/domain/BuildingEnterLog.java
@@ -2,15 +2,14 @@ package com.doubleo.passservice.domain.log.domain;
 
 import com.doubleo.passservice.domain.common.model.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Table(name = "building_enter_log")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class BuildingEnterLog extends BaseEntity {
 
     @Id
@@ -34,24 +33,20 @@ public class BuildingEnterLog extends BaseEntity {
     @Column(name = "direction", nullable = false, length = 10)
     private Direction direction;
 
-    @Builder(access = AccessLevel.PRIVATE)
-    public BuildingEnterLog(
-            Long buildingId, Long memberId, String memberName, Long passId, Direction direction) {
-        this.buildingId = buildingId;
-        this.memberId = memberId;
-        this.memberName = memberName;
-        this.passId = passId;
-        this.direction = direction;
-    }
-
     public static BuildingEnterLog createBuildingEnterLog(
-            Long buildingId, Long memberId, String memberName, Long passId, Direction direction) {
-        return BuildingEnterLog.builder()
-                .buildingId(buildingId)
-                .memberId(memberId)
-                .memberName(memberName)
-                .passId(passId)
-                .direction(direction)
-                .build();
+            Long buildingId,
+            Long memberId,
+            String memberName,
+            Long passId,
+            Direction direction,
+            String tenantId) {
+        BuildingEnterLog log = new BuildingEnterLog();
+        log.buildingId = buildingId;
+        log.memberId = memberId;
+        log.memberName = memberName;
+        log.passId = passId;
+        log.direction = direction;
+        log.tenantId = tenantId;
+        return log;
     }
 }

--- a/src/main/java/com/doubleo/passservice/domain/log/domain/EnterLog.java
+++ b/src/main/java/com/doubleo/passservice/domain/log/domain/EnterLog.java
@@ -45,6 +45,7 @@ public class EnterLog extends BaseEntity {
                 .tenantId(tenantId)
                 .areaId(areaId)
                 .memberId(memberId)
+                .memberName(memberName)
                 .passId(passId)
                 .build();
     }

--- a/src/main/java/com/doubleo/passservice/domain/log/dto/request/CreateAreaEnterLogRequest.java
+++ b/src/main/java/com/doubleo/passservice/domain/log/dto/request/CreateAreaEnterLogRequest.java
@@ -1,0 +1,4 @@
+package com.doubleo.passservice.domain.log.dto.request;
+
+public record CreateAreaEnterLogRequest(
+        String tenantId, Long areaId, Long memberId, String memberName, Long passId) {}

--- a/src/main/java/com/doubleo/passservice/domain/log/dto/request/CreateBuildingEnterLogRequest.java
+++ b/src/main/java/com/doubleo/passservice/domain/log/dto/request/CreateBuildingEnterLogRequest.java
@@ -1,0 +1,11 @@
+package com.doubleo.passservice.domain.log.dto.request;
+
+import com.doubleo.passservice.domain.log.domain.Direction;
+
+public record CreateBuildingEnterLogRequest(
+        String tenantId,
+        Long buildingId,
+        Long memberId,
+        String memberName,
+        Long passId,
+        Direction direction) {}

--- a/src/main/java/com/doubleo/passservice/domain/log/producer/AreaEnterLogStreamProducer.java
+++ b/src/main/java/com/doubleo/passservice/domain/log/producer/AreaEnterLogStreamProducer.java
@@ -1,0 +1,28 @@
+package com.doubleo.passservice.domain.log.producer;
+
+import com.doubleo.passservice.domain.log.dto.request.CreateAreaEnterLogRequest;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AreaEnterLogStreamProducer {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void sendAreaEnterLogToStream(CreateAreaEnterLogRequest request) {
+        Map<String, String> message = new HashMap<>();
+        message.put("tenantId", request.tenantId());
+        message.put("areaId", request.areaId().toString());
+        message.put("memberId", request.memberId().toString());
+        message.put("memberName", request.memberName());
+        message.put("passId", request.passId().toString());
+        message.put("timestamp", LocalDateTime.now().toString());
+
+        redisTemplate.opsForStream().add("area:enter:stream", message);
+    }
+}

--- a/src/main/java/com/doubleo/passservice/domain/log/producer/BuildingEnterLogStreamProducer.java
+++ b/src/main/java/com/doubleo/passservice/domain/log/producer/BuildingEnterLogStreamProducer.java
@@ -1,0 +1,29 @@
+package com.doubleo.passservice.domain.log.producer;
+
+import com.doubleo.passservice.domain.log.dto.request.CreateBuildingEnterLogRequest;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BuildingEnterLogStreamProducer {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void sendBuildingEnterLogToStream(CreateBuildingEnterLogRequest request) {
+        Map<String, String> message = new HashMap<>();
+        message.put("tenantId", request.tenantId());
+        message.put("buildingId", request.buildingId().toString());
+        message.put("memberId", request.memberId().toString());
+        message.put("memberName", request.memberName());
+        message.put("passId", request.passId().toString());
+        message.put("direction", request.direction().name());
+        message.put("timestamp", LocalDateTime.now().toString());
+
+        redisTemplate.opsForStream().add("building:enter:stream", message);
+    }
+}

--- a/src/main/java/com/doubleo/passservice/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/doubleo/passservice/global/config/redis/RedisConfig.java
@@ -47,6 +47,8 @@ public class RedisConfig {
         template.setConnectionFactory(connectionFactory);
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
         return template;
     }
 }


### PR DESCRIPTION
## 🔷 Jira Ticket ID

[KW-592]

---
## 📌 작업 내용 및 특이사항

- 건물 출입 로그를 레디스 스트림에 저장하는 기능 구현하였습니다.
- 기존에는 builder를 사용해 정적 팩토리 메서드 기반의 객체 생성 방식을 사용했지만 BaseEntity의 tenantId 필드를 세팅할 수 없어 new 키워드로 객체를 생성한 후 필드를 직접 할당하는 방식으로 변경했습니다.
- entrance 서비스에서 pass 서비스에 있는 redis에 직접 접근하는 것은 바람직하지 않은 것 같아 gRPC를 통해 pass의 프로듀서를 호출하는 방식으로 구상하였습니다.
- 프로듀서 호출 이후 db에 데이터가 잘 들어가는 것까지 테스트 완료했습니다.

---
## 📚 참고사항

- 리뷰 받고 구역 출입 로그 저장도 pr 올리도록 하겠습니다.


[KW-592]: https://teamdoubleo.atlassian.net/browse/KW-592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ